### PR TITLE
Allow a pull secret to be specified

### DIFF
--- a/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy-latest.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy-latest.yaml
@@ -12,6 +12,10 @@ spec:
       labels:
         name: kata-deploy
     spec:
+{{- with .Values.kataDeploy.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 6 }}
+{{- end }}
       containers:
       - command:
         - bash

--- a/tools/packaging/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/values.yaml
@@ -6,7 +6,7 @@
 
 kataDeploy:
   imagePullPolicy: Always
-  imagePullSecrets: [""]
+  imagePullSecrets: []
   repository: quay.io/kata-containers/kata-deploy
   # version can be latest or development 
   version: "latest"


### PR DESCRIPTION
The helm chart needs allow a pull secret in order to pull from private registries.

@zvonkok PTAL