### PR TITLE
fix: start persistenced before container_toolkit

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -90,8 +90,8 @@ create_udev_rule()
 
 	# If the difference is greater than or equal to wait_time, execute the target script
 	if [ "$time_diff" -ge "$wait_time" ]; then
-	        nvidia_container_toolkit
 		nvidia_persistenced
+	        nvidia_container_toolkit
 	fi
 	CHROOT_EOF
 


### PR DESCRIPTION
In order to make sure persistenced socket is mounted into the container.

@zvonkok PTAL

