### PR TITLE
Fix Container Restart

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -371,17 +371,6 @@ impl AgentService {
         tokio::time::timeout(to, handle)
             .await
             .map_err(|_| anyhow!(nix::Error::ETIME))???;
-
-
-
-        // kill nvidia-persistenced process in the VM
-        info!(sl(), "##### kill $(pidof nvidia-persistenced)");
-        let _ = Command::new("kill")
-            .arg("$(pidof nvidia-persistenced)")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status(); 
-        
         remove_container_resources(&mut *self.sandbox.lock().await, &cid).await
     }
 

--- a/src/runtime/pkg/device/drivers/vfio.go
+++ b/src/runtime/pkg/device/drivers/vfio.go
@@ -48,6 +48,26 @@ func NewVFIODevice(devInfo *config.DeviceInfo) *VFIODevice {
 	}
 }
 
+// getOrUpdateVFIOPortAssignment returns the port assignment for a VFIO device
+// If the VFIO device is already assigned return the port, otherwise
+// assign a new port and return that.
+func getOrUpdateVFIOPortAssignment(existingVFIO []config.VFIODev, incoming config.VFIODev) string {
+	for busIndex, existing := range existingVFIO {
+		if existing.BDF == incoming.BDF {
+			// If it is the very same device update the structure
+			// with the incoming device info and return the bus number
+			config.PCIeDevicesPerPort[incoming.Port][busIndex] = incoming
+			return fmt.Sprintf("%s%d", config.PCIePortPrefixMapping[incoming.Port], busIndex)
+		}
+	}
+	busIndex := len(config.PCIeDevicesPerPort[incoming.Port])
+	// We need to keep track the number of devices per port to deduce
+	// the corectu bus number, additionally we can use the VFIO device
+	// info to act upon different Vendor IDs and Device IDs.
+	config.PCIeDevicesPerPort[incoming.Port] = append(config.PCIeDevicesPerPort[incoming.Port], incoming)
+	return fmt.Sprintf("%s%d", config.PCIePortPrefixMapping[incoming.Port], busIndex)
+}
+
 // Attach is standard interface of api.Device, it's used to add device to some
 // DeviceReceiver
 func (device *VFIODevice) Attach(ctx context.Context, devReceiver api.DeviceReceiver) (retErr error) {
@@ -78,12 +98,11 @@ func (device *VFIODevice) Attach(ctx context.Context, devReceiver api.DeviceRece
 		}
 
 		if vfio.IsPCIe {
-			busIndex := len(config.PCIeDevicesPerPort[vfio.Port])
-			vfio.Bus = fmt.Sprintf("%s%d", config.PCIePortPrefixMapping[vfio.Port], busIndex)
-			// We need to keep track the number of devices per port to deduce
-			// the corectu bus number, additionally we can use the VFIO device
-			// info to act upon different Vendor IDs and Device IDs.
-			config.PCIeDevicesPerPort[vfio.Port] = append(config.PCIeDevicesPerPort[vfio.Port], *vfio)
+			// If the device is already assigned to a port ignore it,
+			// otherwise a container restart will increase the bus
+			// number until we're out of range and fail.
+			existingVFIO := config.PCIeDevicesPerPort[vfio.Port]
+			vfio.Bus = getOrUpdateVFIOPortAssignment(existingVFIO, *vfio)
 		}
 		deviceLogger().Infof("#### VFIO Device: %v, Port: %v, Bus: %v, BDF: %v, SysfsDev: %v, Type: %v, IsPCIe: %v, VendorID: %v, DeviceID: %v", vfio.ID, vfio.Port, vfio.Bus, vfio.BDF, vfio.SysfsDev, vfio.Type, vfio.IsPCIe, vfio.VendorID, vfio.DeviceID)
 	}


### PR DESCRIPTION
If the device is already assigned to a port ignore it, otherwise a container restart will increase the bus number until we're out of range and fail.