### PR TITLE
fix: use pre-delete hook for clean up

### DIFF
--- a/tools/packaging/helm-chart/kata-deploy/templates/kata-pre-delete.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/templates/kata-pre-delete.yaml
@@ -1,0 +1,88 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{.Release.Name}}"
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded,before-hook-creation"
+spec:
+  template:
+    metadata:
+      name: "{{.Release.Name}}"
+      labels:
+        app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+        app.kubernetes.io/instance: {{.Release.Name | quote }}
+        helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    spec:
+{{- with .Values.kataDeploy.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 6 }}
+{{- end }}
+      restartPolicy: Never
+      containers:
+      - command:
+        - bash
+        - -c
+        - /opt/kata-artifacts/scripts/kata-deploy.sh cleanup
+        env:
+        - name: DEBUG
+          value: '{{ .Values.kataDeploy.debug }}'
+        - name: DEFAULT_SHIM
+          value: '{{ .Values.kataDeploy.defaultShim }}'
+        - name: CREATE_RUNTIMECLASSES
+          value: '{{ .Values.kataDeploy.createRuntimeClasses }}'
+        - name: CREATE_DEFAULT_RUNTIMECLASS
+          value: '{{ .Values.kataDeploy.createDefaultRuntimeClass }}'
+        - name: ALLOWED_HYPERVISOR_ANNOTATIONS
+          value: '{{ .Values.kataDeploy.allowedHypervisorAnnotations }}'
+        - name: CONTAINERD_DROP_IN_CONF
+          value: '{{ .Values.kataDeploy.containerdDropInConf }}'
+        - name: SHIMS
+          value: '{{ .Values.kataDeploy.shims }}'
+        - name: INSTALL_PREFIX
+          value: '{{ .Values.kataDeploy.installPrefix }}'
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: SNAPSHOTTER_HANDLER_MAPPING
+          value: ""
+        - name: AGENT_HTTPS_PROXY
+          value: ""
+        - name: AGENT_NO_PROXY
+          value: ""
+        image: '{{ .Values.kataDeploy.repository }}:{{ .Values.kataDeploy.version }}'
+        imagePullPolicy: '{{ .Values.kataDeploy.imagePullPolicy }}'
+        name: kube-kata-clean
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /etc/crio/
+          name: crio-conf
+        - mountPath: /etc/containerd/
+          name: containerd-conf
+        - mountPath: /opt/kata/
+          name: kata-artifacts
+        - mountPath: /usr/local/bin/
+          name: local-bin
+      hostPID: true
+      serviceAccountName: kata-deploy-sa
+      volumes:
+      - hostPath:
+          path: '{{- template "kataDeploy.containerdConfPath" .Values.kataDeploy }}'
+        name: containerd-conf
+      - hostPath:
+          path: /etc/crio/
+        name: crio-conf
+      - hostPath:
+          path: /opt/kata/
+          type: DirectoryOrCreate
+        name: kata-artifacts
+      - hostPath:
+          path: /usr/local/bin/
+        name: local-bin

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -611,6 +611,7 @@ EOF
 			cleanup_cri_runtime "$runtime"
 			kubectl label node "$NODE_NAME" --overwrite katacontainers.io/kata-runtime=cleanup
 			remove_artifacts
+			return 0
 			;;
 		reset)
 			reset_runtime $runtime


### PR DESCRIPTION
Addresses 4608377
During helm chart uninstall, container life cycle hook is unable to run because the service account and rbac gets removed.  This commit adds a pre-delete hook to the chart that performs the clean up.

@zvonkok PTAL.