### PR TITLE
fix: enforce sbr for NVIDIA gpus plus add a delay after sbr

### DIFF
--- a/tools/packaging/qemu/patches/7.2.x/0001-nvidia-bus-reset.patch
+++ b/tools/packaging/qemu/patches/7.2.x/0001-nvidia-bus-reset.patch
@@ -1,0 +1,57 @@
+diff --git a/hw/vfio/pci-quirks.c b/hw/vfio/pci-quirks.c
+index f0147a050a..18af9f6f07 100644
+--- a/hw/vfio/pci-quirks.c
++++ b/hw/vfio/pci-quirks.c
+@@ -1443,7 +1443,15 @@ out:
+ 
+ void vfio_setup_resetfn_quirk(VFIOPCIDevice *vdev)
+ {
++    uint16_t dev_class = 0;
++
+     switch (vdev->vendor_id) {
++    case PCI_VENDOR_ID_NVIDIA:
++	dev_class = vfio_get_pci_class(vdev);
++        if ((dev_class == PCI_CLASS_DISPLAY_VGA) || (dev_class == PCI_CLASS_DISPLAY_3D)) {
++            vdev->vbasedev.reset_works = false;
++        }
++        return;
+     case 0x1002:
+         switch (vdev->device_id) {
+         /* Bonaire */
+diff --git a/hw/vfio/pci.c b/hw/vfio/pci.c
+index 71509f9c7e..2b1d2e0cfc 100644
+--- a/hw/vfio/pci.c
++++ b/hw/vfio/pci.c
+@@ -2378,6 +2378,7 @@ static int vfio_pci_hot_reset(VFIOPCIDevice *vdev, bool single)
+     /* Bus reset! */
+     ret = ioctl(vdev->vbasedev.fd, VFIO_DEVICE_PCI_HOT_RESET, reset);
+     g_free(reset);
++    sleep(SBR_DELAY_SECS);
+ 
+     trace_vfio_pci_hot_reset_result(vdev->vbasedev.name,
+                                     ret ? strerror(errno) : "Success");
+diff --git a/hw/vfio/pci.h b/hw/vfio/pci.h
+index 7c236a52f4..d55c807b6f 100644
+--- a/hw/vfio/pci.h
++++ b/hw/vfio/pci.h
+@@ -22,6 +22,7 @@
+ #include "sysemu/kvm.h"
+ 
+ #define PCI_ANY_ID (~0)
++#define SBR_DELAY_SECS 3
+ 
+ struct VFIOPCIDevice;
+ 
+@@ -192,6 +193,12 @@ static inline bool vfio_is_vga(VFIOPCIDevice *vdev)
+     return class == PCI_CLASS_DISPLAY_VGA;
+ }
+ 
++static inline uint16_t vfio_get_pci_class(VFIOPCIDevice *vdev)
++{
++    PCIDevice *pdev = &vdev->pdev;
++    return pci_get_word(pdev->config + PCI_CLASS_DEVICE);
++}
++
+ uint32_t vfio_pci_read_config(PCIDevice *pdev, uint32_t addr, int len);
+ void vfio_pci_write_config(PCIDevice *pdev,
+                            uint32_t addr, uint32_t val, int len);


### PR DESCRIPTION
The GPU requires a secondary bus reset before it is handed to a kata container. Currently, only an FLR is performed by the kernel. This patch includes the following:

1) Add a pci quirk to QEMU that forces SBR to be used for NVDIA GPUs (VGA and 3D)
2) Add a delay after the reset ioctl and before the vfio_bar_restore
