### PR TITLE
fix: add missing libs plus fix dockerfile

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -25,7 +25,7 @@ RUN \
 	if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
 	DEBIAN_ARCH=${ARCH} && \
 	if [ "${DEBIAN_ARCH}" = "ppc64le" ]; then DEBIAN_ARCH=ppc64el; fi && \
-	curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
+	curl -fL --progress-bar -o /usr/bin/kubectl https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
 	chmod +x /usr/bin/kubectl && \
 	curl -fL --progress-bar -o /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${DEBIAN_ARCH} && \
 	chmod +x /usr/bin/jq && \


### PR DESCRIPTION
1. Additional libraries need to be mounted into the container for applications such as RTX to run. Those libraries are included. They have some files under /usr/share. Hence that clean up has been eliminated.
2. The kata-deploy dockerfile needed a change to fix the kubectl download path.

@zvonkok PTAL