### PR TITLE
fix: update resource and overhead settings

### DIFF
--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -106,7 +106,7 @@ cpu_features="@CPUFEATURES@"
 # < 0                             --> will be set to the actual number of physical cores
 # > 0 <= number of physical cores --> will be set to the specified number
 # > number of physical cores      --> will be set to the actual number of physical cores
-default_vcpus = 16
+default_vcpus = 1
 
 # Default maximum number of vCPUs per SB/VM:
 # unspecified or == 0             --> will be set to the actual number of physical cores or to the maximum number
@@ -139,7 +139,7 @@ default_bridges = @DEFBRIDGES@
 
 # Default memory size in MiB for SB/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
-default_memory = 65536
+default_memory = 4096
 #
 # Default memory slots per SB/VM.
 # If unspecified then it will be set @DEFMEMSLOTS@.

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
@@ -6,8 +6,8 @@ metadata:
 handler: kata-qemu-nvidia-gpu
 overhead:
     podFixed:
-        memory: "160Mi"
-        cpu: "250m"
+        memory: "4096Mi"
+        cpu: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"


### PR DESCRIPTION
Reduce the default memory setting to 4G and the vcpus to 1. Plus update pod overhead settings to match this.

@zvonkok PTAL