### PR TITLE
fix: Set nofile limits for the agent

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_init
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_init
@@ -31,4 +31,6 @@ fi
 nvidia-smi conf-compute -srs 1
 
 # Setting AGENT_INIT to yes will make the agent the init process
+# set the limits here as these are inherited by the containers
+prlimit --pid  $$ --nofile=1048576:1048576
 exec /sbin/init


### PR DESCRIPTION
The agent was defaulting to nofile hard/soft limits of 2048 and 1024 respectively, forcing the same limits on the containers. This fix explicitly sets both limits to 1048576 consistent with runc behavior.

@zvonkok PTAL