### PR TITLE
Split kata-deploy clean up

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -21,7 +21,7 @@ export supported_gpu_devids="/supported-gpu.devids"
 
 APT_INSTALL="apt -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -yqq --no-install-recommends install"
 # Need to override this because ubuntu incorrectly picks 90.12
-NSCQ_VERSION="550.90.07-0ubuntu0.22.04.1"
+#NSCQ_VERSION="550.90.07-0ubuntu0.22.04.1"
 
 set_arch() {
 	if [[ ${arch_target} == x86_64 ]]; then

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_init_functions
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_init_functions
@@ -254,7 +254,7 @@ nvidia_persistenced() {
 perform_cdi_edits() {
 	cat <<-'VDPAU_EOF' > /tmp/cdi_vdpau_mount
 { 
-        "hostPath": "/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.550.90.07",
+        "hostPath": "/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.550.127.05",
         "containerPath": "/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so",
         "options": [
           "ro",

--- a/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -56,7 +56,7 @@ spec:
               command:
               - bash
               - -c
-              - /opt/kata-artifacts/scripts/kata-deploy.sh cleanup
+              - /opt/kata-artifacts/scripts/kata-deploy.sh node-cleanup
         name: kube-kata
         securityContext:
           privileged: true

--- a/tools/packaging/helm-chart/kata-deploy/templates/kata-pre-delete.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/templates/kata-pre-delete.yaml
@@ -28,7 +28,7 @@ spec:
       - command:
         - bash
         - -c
-        - /opt/kata-artifacts/scripts/kata-deploy.sh cleanup
+        - /opt/kata-artifacts/scripts/kata-deploy.sh cluster-cleanup
         env:
         - name: DEBUG
           value: '{{ .Values.kataDeploy.debug }}'

--- a/tools/packaging/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -15,6 +15,7 @@ rules:
   - nodes
   verbs:
   - get
+  - list
   - patch
 - apiGroups:
   - node.k8s.io


### PR DESCRIPTION
commit 1: updates the driver version in the cdi edit. _This commit will be moot when we pick up the latest toolkit_.

commit 2: The current kata-deploy lifecycle hook removes the runtimeclass. This is a problem if a pod in a multi-node cluster exits due to any reason, notably due to eviction. This commit splits the clean up into a cluster level chart hook that removes the runtimeclass and lablels and a pod lifecycle hook that perform node level clean up.

@zvonkok PTAL