### PR TITLE
fix: dcgm with hotplug

### DIFF
--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -139,7 +139,7 @@ default_bridges = @DEFBRIDGES@
 
 # Default memory size in MiB for SB/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
-default_memory = 4096
+default_memory = 8192
 #
 # Default memory slots per SB/VM.
 # If unspecified then it will be set @DEFMEMSLOTS@.

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_init
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_init
@@ -30,6 +30,8 @@ fi
 # TODO setting the GPU in ready mode till KBS has GPU suport
 nvidia-smi conf-compute -srs 1
 
+# watch for hotunplug events reported by dmesg
+/bin/hotunplug_monitor.sh &
 # Setting AGENT_INIT to yes will make the agent the init process
 # set the limits here as these are inherited by the containers
 prlimit --pid  $$ --nofile=1048576:1048576

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_init_functions
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_init_functions
@@ -152,6 +152,50 @@ nvidia_udev_setup() {
 	/etc/init.d/udev start
 }
 
+mutex_lock_dir() {
+        while ! $(mkdir /tmp/$1 >&/dev/NULL); do
+                PID=$(cat /tmp/$1/pid) || true
+                echo "waiting for $PID"
+                sleep 1
+        done
+        echo "$$" > /tmp/$1/pid
+}
+
+mutex_unlock_dir() {
+        PID=$(cat /tmp/$1/pid) || true
+        if [[ "$PID" != "$$" ]]; then
+                echo "WARNING: lock held by $PID, unlocked by $$"
+        fi
+        rm -rf /tmp/$1
+}
+
+get_cmdline_var() {
+	if cat /proc/cmdline | grep "$1=" >/dev/null; then
+		echo "$(cat /proc/cmdline | sed -e "s/^.*$1=//" -e 's/ .*$//')"
+	else
+		echo ""
+	fi
+}
+
+restart_nvidia_svcs() {
+	DISABLE_NVIDIA_SVCS=$(get_cmdline_var disable_nvidia_svcs)
+	if [[ "$DISABLE_NVIDIA_SVCS" == "true" ]]; then
+                echo "disable_nvidia_svcs set to $DISABLE_NVIDIA_SVCS"
+                echo "Ignoring restart_nvidia_svcs"
+		return 0
+	fi
+        mutex_lock_dir hotplug.lck
+        service dcgmexporter stop || true
+        service persistenced stop || true
+        service hostengine stop || true
+        sleep $1
+        service persistenced start || true
+        service hostengine start || true
+        service dcgmexporter start || true
+        echo "restarted services"
+        mutex_unlock_dir hotplug.lck
+}
+
 # We need to know if we're running on AMD or Intel CPUs, rename it to amd or intel
 nvidia_query_cpu_vendor() {
 	local cpu_vendor_file="/proc/cpuinfo"
@@ -290,8 +334,7 @@ nvidia_container_toolkit() {
 	nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.json
 	perform_cdi_edits
 	nvidia-ctk cdi generate --mode=management --vendor=management.nvidia.com --output=/var/run/cdi/management.nvidia.yaml
-	nv-hostengine --service-account nvidia-dcgm --home-dir /tmp
-	dcgm-exporter &
+	restart_nvidia_svcs 1
 }
 
 OBSOLETE_nvidia_verifier_hook() {

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
@@ -6,7 +6,7 @@ metadata:
 handler: kata-qemu-nvidia-gpu
 overhead:
     podFixed:
-        memory: "4096Mi"
+        memory: "8192Mi"
         cpu: "1"
 scheduling:
   nodeSelector:


### PR DESCRIPTION
Summary of changes:
- Defined init.d services for persistenced, nv-hostengine and dcgm-exporter
- Added gpu hotplug hooks to restart these services.
- Added a dmesg based workaround for detecting gpu hot unplug events
- Hooked service restarts to the unplug events detected using the dmesg workaround
- Added mutex locks to the service restarts
- Added an option to disable these services using a kernel command line parameter settable via the config file

Testing:
Tested using single and multiple GPUS, verified

- DCGM metrics are accessible using curl
- Containers can be restarted
- Pods can be deleted

@zvonkok PTAL