### PR TITLE
fix: set default upgrage type to onDelete

### DIFF
--- a/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -86,6 +86,4 @@ spec:
           path: /usr/local/bin/
         name: local-bin
   updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
+    type: '{{ .Values.kataDeploy.updateStrategy }}'

--- a/tools/packaging/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/values.yaml
@@ -20,3 +20,4 @@ kataDeploy:
   allowedHypervisorAnnotations: ""
   containerdDropInConf: ""
   installPrefix: "/usr/local/bin"
+  updateStrategy: onDelete


### PR DESCRIPTION
Rolling upgrade does not work on clusters that already have running workloads because the upgrade will try to overwrite binaries that are in use. In order to address this, an updateStrategy option is added to the helm chart, with default set to onDelete. This enables a drain and update strategy, useful for active clusters.

@zvonkok PTAL