### PR TITLE
Revert "fix: workaround for missing symlinks"

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -266,7 +266,7 @@ cleanup_rootfs()
 		apt purge -yqq "${i}"
 	done
 
-	apt purge -yqq make gcc wget libc6-dev git xz-utils curl gpg \
+	apt purge -yqq jq make gcc wget libc6-dev git xz-utils curl gpg \
 		python3-pip software-properties-common ca-certificates  \
 		linux-libc-dev nuitka python3-minimal
 		
@@ -540,7 +540,6 @@ install_build_dependencies()
 {
 	echo "chroot: Install NVIDIA drivers build dependencies"
 	eval "${APT_INSTALL}" make gcc kmod libvulkan1 pciutils jq 
-        apt-mark hold jq
 }
 
 setup_apt_repositories() 

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_init_functions
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_init_functions
@@ -295,44 +295,12 @@ nvidia_persistenced() {
 
 }
 
-perform_cdi_edits() {
-	cat <<-'VDPAU_EOF' > /tmp/cdi_vdpau_mount
-{ 
-        "hostPath": "/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so.550.127.05",
-        "containerPath": "/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so",
-        "options": [
-          "ro",
-          "nosuid",
-          "nodev",
-          "bind"
-        ]
-},
-VDPAU_EOF
-
-     cat <<-'LINK_EOF' > /tmp/cdi_vdpau_link
-"--link", 
-     "libvdpau_nvidia.so.1::/usr/lib/x86_64-linux-gnu/vdpau/libvdpau_nvidia.so",
-"--link", 
-     "libcuda.so.1::/usr/lib/x86_64-linux-gnu/libcuda.so",
-LINK_EOF
-
-     cat <<-'LDCACHE_EOF' > /tmp/cdi_vdpau_ldcache
-"--folder",
-     "/usr/lib/x86_64-linux-gnu/vdpau",
-LDCACHE_EOF
-
-     cat /var/run/cdi/nvidia.json | jq -r > /tmp/nvidia.json.raw
-     sed '/mounts/ r /tmp/cdi_vdpau_mount' /tmp/nvidia.json.raw | sed '/create-symlinks/ r /tmp/cdi_vdpau_link' | sed '/update-ldcache/ r /tmp/cdi_vdpau_ldcache' > /tmp/nvidia_cdi.json
-     jq -c . /tmp/nvidia_cdi.json > /var/run/cdi/nvidia.json
-}
-
 nvidia_container_toolkit() {
 	nvidia-ctk system create-device-nodes --control-devices --load-kernel-modules
 	
 	nvidia_persistenced
 
 	nvidia-ctk cdi generate --output=/var/run/cdi/nvidia.json
-	perform_cdi_edits
 	nvidia-ctk cdi generate --mode=management --vendor=management.nvidia.com --output=/var/run/cdi/management.nvidia.yaml
 	restart_nvidia_svcs 1
 }


### PR DESCRIPTION
This reverts commit 7780909ec77f980a32fa4ef6bcccc74906353f97, with the toolkit updated to incorporate the missing symlinks.