### PR TITLE
feat: add a batch exec option to kata-runtime

### DIFF
--- a/src/runtime/cmd/kata-runtime/main.go
+++ b/src/runtime/cmd/kata-runtime/main.go
@@ -122,6 +122,7 @@ var runtimeCommands = []cli.Command{
 	kataCheckCLICommand,
 	kataEnvCLICommand,
 	kataExecCLICommand,
+	kataExecBatchCLICommand,
 	kataMetricsCLICommand,
 	factoryCLICommand,
 	kataVolumeCommand,


### PR DESCRIPTION
This changeset adds a batch command execution option to the kata-runtime tool, useful for troubleshooting issues with the kata VM.
e.g.

```
/opt/kata/bin/kata-runtime --config /opt/kata/share/defaults/kata-containers/configuration-qemu-nvidia-gpu.toml exec-batch --command "lspci -nnk -d 10de:" <sandbox-id>
root@localhost:/# 
root@localhost:/# lspci -nnk -d 10de:
02:00.0 3D controller [0302]: NVIDIA Corporation GA100 [A100 PCIe 40GB] [10de:20f1] (rev a1)
	Subsystem: NVIDIA Corporation GA100 [A100 PCIe 40GB] [10de:145f]
	Kernel driver in use: nvidia
	Kernel modules: nvidia_drm, nvidia
root@localhost:/# exit
exit
```

Existing exec option can be used for interactive debugging, but collecting information using a script is difficult. This option enables such collection using a bash script.

@zvonkok PTAL