### PR TITLE
fix: make sure a tagged version of dcgm exporter is picked up

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -15,6 +15,7 @@ export rootfs_type=$5
 export driver_source=""
 # For open source drivers driver_type="-open" otherwise driver_type="" 
 export driver_version="${NVIDIA_DRIVER_VERSION}"
+export dcgm_version="${DCGM_VERSION:=3.3.9-3.6.1}"
 export driver_source_version=""
 export driver_type="-open"
 export supported_gpu_devids="/supported-gpu.devids"
@@ -703,6 +704,7 @@ install_nvidia_dcgm_exporter()
 	git clone https://github.com/NVIDIA/${dex}
 
 	cd ${dex}
+	git checkout tags/${dcgm_version}
 	make binary check-format
 
 	cp cmd/${dex}/${dex} /usr/bin/


### PR DESCRIPTION
We were picking up the top of the tree, which is not stable. This commit ensures a released version is picked up.

@zvonkok PTAL