### PR TITLE
fix: add sbr in exit path and space out gpu unplugs

### DIFF
--- a/src/runtime/pkg/device/quirks/quirks.go
+++ b/src/runtime/pkg/device/quirks/quirks.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2024 Nvidia Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package quirks
+
+import (
+	"math/rand"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	maxLockTries    = 200
+	HotPlugDelaySec = 12
+)
+
+var HotplugFifoName = "/tmp/.nvidiaHotPlugFIFO"
+var HotPlugQuirksDisabled = false
+var HotPlugDelay = HotPlugDelaySec * time.Second
+var fifoMutex = &sync.Mutex{}
+
+func ExecHotPlugQuirks(logger *logrus.Entry) error {
+	if HotPlugQuirksDisabled {
+		return nil
+	}
+	// avoid concurrency within
+	fifoMutex.Lock()
+	defer fifoMutex.Unlock()
+
+	f, err := os.OpenFile(HotplugFifoName, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fifoLock := &unix.Flock_t{
+		Type:   unix.F_WRLCK,
+		Whence: unix.SEEK_SET,
+		Start:  0,
+		Len:    1024,
+	}
+	for ix := 0; ix < maxLockTries; ix++ {
+		err = unix.FcntlFlock(f.Fd(), unix.F_SETLK, fifoLock)
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if err != nil {
+		// insert random delay and return
+		logger.Infof("Failed to acquire lock, using random delay err:%v", err)
+		time.Sleep(getRandomDelay())
+		return nil
+	}
+
+	fifoUnlock := &unix.Flock_t{
+		Type:   unix.F_UNLCK,
+		Whence: unix.SEEK_SET,
+		Start:  0,
+		Len:    1024,
+	}
+	delay := getFifoDelay(logger)
+	// unlock before sleeping to let other processes read the fifo
+	unix.FcntlFlock(f.Fd(), unix.F_SETLK, fifoUnlock)
+	logger.Infof("QUIRK: Sleeping for:%d milliseconds",
+		delay.Milliseconds())
+	time.Sleep(delay)
+	return nil
+}
+
+func getFifoDelay(logger *logrus.Entry) time.Duration {
+	var err error
+	var fifoTS time.Time
+	var delay time.Duration
+
+	delay = time.Millisecond // default to a non-zero value
+	newTS := time.Now().Add(HotPlugDelay)
+	fts := &fifoTS
+
+	hpTS, err := os.ReadFile(HotplugFifoName)
+	if err != nil {
+		logger.Errorf("Failed to read %s %v", HotplugFifoName, err)
+	} else {
+		err = fts.UnmarshalBinary(hpTS)
+		if err != nil {
+			logger.Errorf("Failed to unmarshal ts %v", err)
+		} else {
+			now := time.Now()
+			if fifoTS.After(now) {
+				delay = fifoTS.Sub(now)
+				newTS = fifoTS.Add(HotPlugDelay)
+			}
+		}
+	}
+	newTSData, err := newTS.MarshalBinary()
+	if err != nil {
+		logger.Errorf("Failed to marshal ts %v", err)
+	} else {
+		err = os.WriteFile(HotplugFifoName, newTSData, 0644)
+		if err != nil {
+			logger.Errorf("Failed to write %s %v", HotplugFifoName, err)
+		}
+	}
+
+	return delay
+}
+
+func getRandomDelay() time.Duration {
+	n := HotPlugDelaySec + rand.Intn(10*HotPlugDelaySec)
+	return time.Duration(n) * time.Second
+}

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/drivers"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/quirks"
 	hv "github.com/kata-containers/kata-containers/src/runtime/pkg/hypervisors"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	pkgUtils "github.com/kata-containers/kata-containers/src/runtime/pkg/utils"
@@ -1873,6 +1874,8 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 	} else {
 
 		q.Logger().WithField("dev-id", device.ID).Info("Start hot-unplug VFIO device")
+		quirks.ExecHotPlugQuirks(q.Logger())
+		q.Logger().WithField("dev-id", device.ID).Info("Quirk delayed hot-unplug VFIO device")
 
 		if q.state.HotPlugVFIO == config.BridgePort {
 			if err := q.arch.removeDeviceFromBridge(device.ID); err != nil {

--- a/tools/packaging/qemu/patches/7.2.x/0001-nvidia-bus-reset.patch
+++ b/tools/packaging/qemu/patches/7.2.x/0001-nvidia-bus-reset.patch
@@ -1,0 +1,114 @@
+diff --git a/hw/vfio/pci-quirks.c b/hw/vfio/pci-quirks.c
+index f0147a050a..0dc01fe5a4 100644
+--- a/hw/vfio/pci-quirks.c
++++ b/hw/vfio/pci-quirks.c
+@@ -1441,6 +1441,21 @@ out:
+     return ret;
+ }
+ 
++void vfio_exit_quirks(VFIOPCIDevice *vdev)
++{
++    uint16_t dev_class = 0;
++
++    if (vdev->vendor_id == PCI_VENDOR_ID_NVIDIA) {
++        dev_class = vfio_get_pci_class(vdev);
++        if ((dev_class == PCI_CLASS_DISPLAY_VGA) || (dev_class == PCI_CLASS_DISPLAY_3D)) {
++            /* perform a bus reset */
++            vfio_pci_hot_reset(vdev, true, true);
++            sleep(SBR_DELAY_SECS);
++        }
++    }
++
++}
++
+ void vfio_setup_resetfn_quirk(VFIOPCIDevice *vdev)
+ {
+     switch (vdev->vendor_id) {
+diff --git a/hw/vfio/pci.c b/hw/vfio/pci.c
+index 71509f9c7e..76f2a89736 100644
+--- a/hw/vfio/pci.c
++++ b/hw/vfio/pci.c
+@@ -2247,7 +2247,7 @@ static bool vfio_pci_host_match(PCIHostDeviceAddress *addr, const char *name)
+     return (strcmp(tmp, name) == 0);
+ }
+ 
+-static int vfio_pci_hot_reset(VFIOPCIDevice *vdev, bool single)
++int vfio_pci_hot_reset(VFIOPCIDevice *vdev, bool single, bool reset_only)
+ {
+     VFIOGroup *group;
+     struct vfio_pci_hot_reset_info *info;
+@@ -2381,6 +2381,9 @@ static int vfio_pci_hot_reset(VFIOPCIDevice *vdev, bool single)
+ 
+     trace_vfio_pci_hot_reset_result(vdev->vbasedev.name,
+                                     ret ? strerror(errno) : "Success");
++    if (reset_only) {
++        goto out_reset_only;
++    }
+ 
+ out:
+     /* Re-enable INTx on affected devices */
+@@ -2424,6 +2427,7 @@ out_single:
+     if (!single) {
+         vfio_pci_post_reset(vdev);
+     }
++out_reset_only:
+     g_free(info);
+ 
+     return ret;
+@@ -2446,13 +2450,13 @@ out_single:
+  */
+ static int vfio_pci_hot_reset_one(VFIOPCIDevice *vdev)
+ {
+-    return vfio_pci_hot_reset(vdev, true);
++    return vfio_pci_hot_reset(vdev, true, false);
+ }
+ 
+ static int vfio_pci_hot_reset_multi(VFIODevice *vbasedev)
+ {
+     VFIOPCIDevice *vdev = container_of(vbasedev, VFIOPCIDevice, vbasedev);
+-    return vfio_pci_hot_reset(vdev, false);
++    return vfio_pci_hot_reset(vdev, false, false);
+ }
+ 
+ static void vfio_pci_compute_needs_reset(VFIODevice *vbasedev)
+@@ -3196,6 +3200,7 @@ static void vfio_exitfn(PCIDevice *pdev)
+ {
+     VFIOPCIDevice *vdev = VFIO_PCI(pdev);
+ 
++    vfio_exit_quirks(vdev);
+     vfio_unregister_req_notifier(vdev);
+     vfio_unregister_err_notifier(vdev);
+     pci_device_set_intx_routing_notifier(&vdev->pdev, NULL);
+diff --git a/hw/vfio/pci.h b/hw/vfio/pci.h
+index 7c236a52f4..53f4bac60f 100644
+--- a/hw/vfio/pci.h
++++ b/hw/vfio/pci.h
+@@ -22,6 +22,7 @@
+ #include "sysemu/kvm.h"
+ 
+ #define PCI_ANY_ID (~0)
++#define SBR_DELAY_SECS 5
+ 
+ struct VFIOPCIDevice;
+ 
+@@ -192,6 +193,12 @@ static inline bool vfio_is_vga(VFIOPCIDevice *vdev)
+     return class == PCI_CLASS_DISPLAY_VGA;
+ }
+ 
++static inline uint16_t vfio_get_pci_class(VFIOPCIDevice *vdev)
++{
++    PCIDevice *pdev = &vdev->pdev;
++    return pci_get_word(pdev->config + PCI_CLASS_DEVICE);
++}
++
+ uint32_t vfio_pci_read_config(PCIDevice *pdev, uint32_t addr, int len);
+ void vfio_pci_write_config(PCIDevice *pdev,
+                            uint32_t addr, uint32_t val, int len);
+@@ -225,5 +232,7 @@ int vfio_pci_nvlink2_init(VFIOPCIDevice *vdev, Error **errp);
+ void vfio_display_reset(VFIOPCIDevice *vdev);
+ int vfio_display_probe(VFIOPCIDevice *vdev, Error **errp);
+ void vfio_display_finalize(VFIOPCIDevice *vdev);
++int vfio_pci_hot_reset(VFIOPCIDevice *vdev, bool single, bool reset_only);
++void vfio_exit_quirks(VFIOPCIDevice *vdev);
+ 
+ #endif /* HW_VFIO_VFIO_PCI_H */


### PR DESCRIPTION
This commit adds the following:

1. A QEMU patch that adds a secondary bus reset(SBR) in the GPU hot unplug path
2. A delay between consecutive VFIO hot unplug operations to the `containerd-shim-kata-v2`

@zvonkok PTAL

