### PR TITLE
chart fixes

### DIFF
--- a/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -43,7 +43,7 @@ spec:
         - name: INSTALL_PREFIX
           value: '{{ .Values.kataDeploy.installPrefix }}'
         - name: SETUP_GPU_FEATURE_DISCOVERY
-          value: '{{ .Values.kataGpuFeatureDiscovery }}'
+          value: '{{ .Values.kataGpuFeatureDiscovery.enabled }}'
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -87,8 +87,8 @@ function delete_runtimeclasses() {
 function get_container_runtime() {
 
 	local runtime=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}')
-	if [ "$?" -ne 0 ]; then
-                die "invalid node name"
+	if [ "$?" -ne 0 ] || [ -z "$runtime" ]; then
+                die "invalid node name or access error"
 	fi
 
 	if echo "$runtime" | grep -qE "cri-o"; then


### PR DESCRIPTION
Two miscellaneous fixes are included:
1) kata-deploy has an additional check for kubectl return result as the exit code is not reliable (likely a kubectl bug):
```
++ get_container_runtime
E0305 01:39:58.565714 1997592 memcache.go:265] "Unhandled Error" err="couldn't get current server API group list: Get \"[https://10.96.0.1:443/api?timeout=32s](https://10.96.0.1/api?timeout=32s)\": dial tcp 10.96.0.1:443: i/o timeout"
Unable to connect to the server: dial tcp 10.96.0.1:443: i/o timeout
++ local runtime=
++ '[' 0 -ne 0 ']'
```
In this case, kubectl incorrectly exits with 0, messing up the script.

2) Fix an incorrect variable reference caused by a recent change.