### PR TITLE
fix: set oops=panic to prevent sandbox hanging

### DIFF
--- a/src/runtime/config/configuration-qemu-nvidia-gpu-256g.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-256g.toml.in
@@ -71,7 +71,7 @@ valid_hypervisor_paths = @QEMUVALIDHYPERVISORPATHS@
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELPARAMS@ agent.hotplug_timeout=20"
+kernel_params = "@KERNELPARAMS@ oops=panic agent.hotplug_timeout=20"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-512g.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-512g.toml.in
@@ -71,7 +71,7 @@ valid_hypervisor_paths = @QEMUVALIDHYPERVISORPATHS@
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELPARAMS@ agent.hotplug_timeout=20"
+kernel_params = "@KERNELPARAMS@ oops=panic agent.hotplug_timeout=20"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-708g.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-708g.toml.in
@@ -71,7 +71,7 @@ valid_hypervisor_paths = @QEMUVALIDHYPERVISORPATHS@
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELPARAMS@ agent.hotplug_timeout=20"
+kernel_params = "@KERNELPARAMS@ oops=panic agent.hotplug_timeout=20"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -71,7 +71,7 @@ valid_hypervisor_paths = @QEMUVALIDHYPERVISORPATHS@
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELPARAMS@ agent.hotplug_timeout=20"
+kernel_params = "@KERNELPARAMS@ oops=panic agent.hotplug_timeout=20"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty


### PR DESCRIPTION
This addresses the issue of Pods stuck in terminating state. In this case, the logs show that the VM kernel has hit an oops:
```
"[  647.740105] BUG: kernel NULL pointer dereference, address: 00000000000004b8"
"[  647.740285] #PF: supervisor read access in kernel mode"
"[  647.740330] #PF: error_code(0x0000) - not-present page"
"[  647.740367] PGD 1a2e6c067 P4D 1a2e6c067 PUD 1a2e6d067 PMD 0 "
"[  647.740422] Oops: 0000 [#1] SMP NOPTI"
```

However, since the panic on oops is not configured, it stays in stuck state, without responding to commands from the shim. The fix is to allow the panic so the sandbox can be cleaned up.

@zvonkok PTAL